### PR TITLE
some fixes to make it a real alternative to gnu msgfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ msgcmp
 msgattrib
 msggen
 msgexec
+autopoint
 msgmerge
 msginit
 gettextize

--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -352,6 +352,7 @@ int main(int argc, char**argv) {
 					streq(A+2, "check-accelerators") ||
 					streq(A+2, "no-hash") ||
 					streq(A+2, "verbose") ||
+					streq(A+2, "v") ||
 					strstarts(A+2, "check-accelerators=") ||
 					strstarts(A+2, "resource=") ||
 					strstarts(A+2, "locale=")
@@ -377,7 +378,7 @@ int main(int argc, char**argv) {
 				streq(A+1, "c") ||
 				streq(A+1, "C")
 			) {
-			} else if (streq(A+1, "v")) {
+			} else if (streq(A+1, "V")) {
 				version();
 			} else if (streq(A+1, "d")) {
 				// no support for -d at this time

--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -273,7 +273,7 @@ int process(FILE *in, FILE *out) {
 			d.strbuffer[pe_msgid] = calloc(d.len[pe_msgid], 1);
 			d.strbuffer[pe_msgstr] = calloc(d.len[pe_msgstr], 1);
 			d.stroff[pe_msgid] = d.stroff[pe_msgstr] = 0;
-			assert(d.strlist && d.translist && d.strbuffer[0] && d.strbuffer[1]);
+			assert(d.strlist && d.translist && d.strbuffer[pe_msgid] && d.strbuffer[pe_msgstr]);
 		}
 		poparser_init(p, convbuf, sizeof(convbuf), process_line_callback, &d);
 
@@ -289,16 +289,16 @@ int process(FILE *in, FILE *out) {
 	cb_for_qsort = &d;
 	qsort(d.strlist, d.num[pe_msgid], sizeof (struct strmap), strmap_comp);
 	unsigned i;
-	for(i = 0; i < d.num[0]; i++) {
+	for(i = 0; i < d.num[pe_msgid]; i++) {
 		d.strlist[i].str.off += d.off;
 		fwrite(&d.strlist[i].str, sizeof(struct strtbl), 1, d.out);
 	}
-	for(i = 0; i < d.num[1]; i++) {
+	for(i = 0; i < d.num[pe_msgstr]; i++) {
 		d.strlist[i].trans->off += d.off + d.len[0];
 		fwrite(d.strlist[i].trans, sizeof(struct strtbl), 1, d.out);
 	}
-	fwrite(d.strbuffer[0], d.len[0], 1, d.out);
-	fwrite(d.strbuffer[1], d.len[1], 1, d.out);
+	fwrite(d.strbuffer[pe_msgid], d.len[pe_msgid], 1, d.out);
+	fwrite(d.strbuffer[pe_msgstr], d.len[pe_msgstr], 1, d.out);
 
 	return 0;
 }

--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -89,9 +89,9 @@ struct callbackdata {
 	unsigned pllen2;
 	char msgctxtbuf[4096];
 	unsigned ctxtlen;
-	char msgstrbuf1[4096];
+	char msgstrbuf1[8120];
 	unsigned mslen1;
-	char msgstrbuf2[4096];
+	char msgstrbuf2[8120];
 	unsigned mslen2;
 	unsigned msc;
 	unsigned priv_type;

--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -323,22 +323,27 @@ int process_line_callback(struct po_info* info, void* user) {
 					writestr(d, info);
 					// just copy, it's written down when writemsg()
 					if(i==0) {
+						assert(l+1 <= sizeof(d->msgidbuf1));
 						memcpy(d->msgidbuf1, sysdeps[i], l+1);
 						d->milen1 = l+1;
 					} else {
+						assert(l+1 <= sizeof(d->msgidbuf2));
 						memcpy(d->msgidbuf2, sysdeps[i], l+1);
 						d->milen2 = l+1;
 					}
 				} else if(info->type == pe_plural) {
 					if(i==0) {
+						assert(l+1 <= sizeof(d->pluralbuf1));
 						memcpy(d->pluralbuf1, sysdeps[i], l+1);
 						d->pllen1 = l+1;
 					} else {
+						assert(l+1 <= sizeof(d->pluralbuf2));
 						memcpy(d->pluralbuf2, sysdeps[i], l+1);
 						d->pllen2 = l+1;
 					}
 				} else if(info->type == pe_ctxt) {
 					writestr(d, info);
+					assert(l+1 <= sizeof(d->msgctxtbuf));
 					d->ctxtlen = l+1;
 					memcpy(d->msgctxtbuf, sysdeps[i], l);
 					d->msgctxtbuf[l] = 0x4;//EOT
@@ -346,11 +351,13 @@ int process_line_callback(struct po_info* info, void* user) {
 					writemsg(d);
 					// just copy, it's written down when writestr()
 					if(i==0) {
+						assert(l+1 <= sizeof(d->msgstrbuf1)/info->nplurals);
 						memcpy(&d->msgstrbuf1[d->mslen1], sysdeps[i], l+1);
 						d->mslen1 += l+1;
 						d->msc++;
 					} else {
 						// sysdeps exist
+						assert(l+1 <= sizeof(d->msgstrbuf2)/info->nplurals);
 						memcpy(&d->msgstrbuf2[d->mslen2], sysdeps[i], l+1);
 						d->mslen2 += l+1;
 					}

--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -268,10 +268,10 @@ int process(FILE *in, FILE *out) {
 			d.off = mohdr.off_tbl_trans + d.num[pe_msgid] * (sizeof(unsigned)*2);
 			if(invalid_file) return 0;
 
-			d.strlist = malloc(d.num[pe_msgid] * sizeof(struct strmap));
-			d.translist = malloc(d.num[pe_msgstr] * sizeof(struct strtbl));
-			d.strbuffer[pe_msgid] = malloc(d.len[pe_msgid]);
-			d.strbuffer[pe_msgstr] = malloc(d.len[pe_msgstr]);
+			d.strlist = calloc(d.num[pe_msgid] * sizeof(struct strmap), 1);
+			d.translist = calloc(d.num[pe_msgstr] * sizeof(struct strtbl), 1);
+			d.strbuffer[pe_msgid] = calloc(d.len[pe_msgid], 1);
+			d.strbuffer[pe_msgstr] = calloc(d.len[pe_msgstr], 1);
 			d.stroff[pe_msgid] = d.stroff[pe_msgstr] = 0;
 			assert(d.strlist && d.translist && d.strbuffer[0] && d.strbuffer[1]);
 		}

--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -350,7 +350,7 @@ int process(FILE *in, FILE *out) {
 		if(d.pass == pass_second) {
 			// start of second pass:
 			// check that data gathered in first pass is consistent
-			if((d.num[pe_msgid] + d.num[pe_plural] * (p->info.nplurals - 1)) != d.num[pe_msgstr]) {
+			if((d.num[pe_msgid] + d.num[pe_plural] * (p->info.nplurals - 1)) < d.num[pe_msgstr]) {
 				// one should actually abort here,
 				// but gnu gettext simply writes an empty .mo and returns success.
 				//abort();

--- a/src/poparser.h
+++ b/src/poparser.h
@@ -14,6 +14,7 @@ enum po_entry {
 struct po_info {
 	enum po_entry type;
 	char *text;
+	char charset[12];
 	size_t textlen;
 };
 

--- a/src/poparser.h
+++ b/src/poparser.h
@@ -4,6 +4,7 @@
 
 enum po_entry {
 	pe_msgid = 0,
+	pe_plural,
 	pe_msgstr,
 	pe_maxstr,
 	pe_str = pe_maxstr,
@@ -15,6 +16,7 @@ struct po_info {
 	enum po_entry type;
 	char *text;
 	char charset[12];
+	unsigned int nplurals;
 	size_t textlen;
 };
 

--- a/src/poparser.h
+++ b/src/poparser.h
@@ -5,6 +5,7 @@
 enum po_entry {
 	pe_msgid = 0,
 	pe_plural,
+	pe_ctxt,
 	pe_msgstr,
 	pe_maxstr,
 	pe_str = pe_maxstr,


### PR DESCRIPTION
1. automatically convert to UTF-8, if the encoding of file is unknown, then do nothing
2. v stands for verbose and V stands for version now
3. multiple plurals support
4. skip fuzzy marked strings
#9 