### PR TITLE
ABOUT-NLS destination fix and added Makevars.template

### DIFF
--- a/data/Makevars.template
+++ b/data/Makevars.template
@@ -1,0 +1,82 @@
+# Makefile variables for PO directory in any package using GNU gettext.
+#
+# Copyright (C) 2003-2017 Free Software Foundation, Inc.
+# This file, Makevars,template, is free software; the Free Software Foundation
+# gives unlimited permission to use, copy, distribute, and modify it.
+
+# Usually the message domain is the same as the package name.
+DOMAIN = $(PACKAGE)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+# These options get passed to xgettext.
+XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
+
+# This is the copyright holder that gets inserted into the header of the
+# $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding
+# package.  (Note that the msgstr strings, extracted from the package's
+# sources, belong to the copyright holder of the package.)  Translators are
+# expected to transfer the copyright for their translations to this person
+# or entity, or to disclaim their copyright.  The empty string stands for
+# the public domain; in this case the translators are expected to disclaim
+# their copyright.
+COPYRIGHT_HOLDER = Free Software Foundation, Inc.
+
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU =
+
+# This is the email address or URL to which the translators shall report
+# bugs in the untranslated strings:
+# - Strings which are not entire sentences, see the maintainer guidelines
+#   in the GNU gettext documentation, section 'Preparing Strings'.
+# - Strings which use unclear terms or require additional context to be
+#   understood.
+# - Strings which make invalid assumptions about notation of date, time or
+#   money.
+# - Pluralisation problems.
+# - Incorrect English spelling.
+# - Incorrect formatting.
+# It can be your email address, or a mailing list address where translators
+# can write to without being subscribed, or the URL of a web page through
+# which the translators can contact you.
+MSGID_BUGS_ADDRESS =
+
+# This is the list of locale categories, beyond LC_MESSAGES, for which the
+# message catalogs shall be used.  It is usually empty.
+EXTRA_LOCALE_CATEGORIES =
+
+# This tells whether the $(DOMAIN).pot file contains messages with an 'msgctxt'
+# context.  Possible values are "yes" and "no".  Set this to yes if the
+# package uses functions taking also a message context, like pgettext(), or
+# if in $(XGETTEXT_OPTIONS) you define keywords with a context argument.
+USE_MSGCTXT = no
+
+# These options get passed to msgmerge.
+# Useful options are in particular:
+#   --previous            to keep previous msgids of translated messages,
+#   --quiet               to reduce the verbosity.
+MSGMERGE_OPTIONS =
+
+# These options get passed to msginit.
+# If you want to disable line wrapping when writing PO files, add
+# --no-wrap to MSGMERGE_OPTIONS, XGETTEXT_OPTIONS, and
+# MSGINIT_OPTIONS.
+MSGINIT_OPTIONS =
+
+# This tells whether or not to regenerate a PO file when $(DOMAIN).pot
+# has changed.  Possible values are "yes" and "no".  Set this to no if
+# the POT file is checked in the repository and the version control
+# program ignores timestamps.
+PO_DEPENDS_ON_POT = yes
+
+# This tells whether or not to forcibly update $(DOMAIN).pot and
+# regenerate PO files on "make dist".  Possible values are "yes" and
+# "no".  Set this to no if the POT file and PO files are maintained
+# externally.
+DIST_DEPENDS_ON_UPDATE_PO = yes

--- a/src/autopoint.in
+++ b/src/autopoint.in
@@ -21,4 +21,6 @@ touch ./${dirprefix}/config.rpath ABOUT-NLS
 for i in intl/Makefile.in po/Makefile.in.in ; do
 	install -D -m 644 @datadir@/data/autopoint_Makefile.in "$i"
 done
+
+install -D -m 644 @datadir@/data/Makevars.template po/Makevars.template
 true

--- a/src/autopoint.in
+++ b/src/autopoint.in
@@ -16,7 +16,7 @@ do
   fi
 done < "configure.ac"
 
-touch ./${dirprefix}/config.rpath ./${dirprefix}/ABOUT-NLS
+touch ./${dirprefix}/config.rpath ABOUT-NLS
 
 for i in intl/Makefile.in po/Makefile.in.in ; do
 	install -D -m 644 @datadir@/data/autopoint_Makefile.in "$i"


### PR DESCRIPTION
This is fix for bug we created in solving issue https://github.com/sabotage-linux/gettext-tiny/issues/18 and added `Makevars.template` in order to compile `bison` package