### PR TITLE
msgfmt: Raise buffer size limits

### DIFF
--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -370,8 +370,8 @@ int process_line_callback(struct po_info* info, void* user) {
 
 int process(FILE *in, FILE *out) {
 	struct mo_hdr mohdr = def_hdr;
-	char line[4096]; char *lp;
-	char convbuf[16384];
+	char line[8192]; char *lp;
+	char convbuf[32768];
 
 	struct callbackdata d = {
 		.num = {


### PR DESCRIPTION
In the Dzongkha translation of GConf 3.2.6, msgfmt aborts because a line
is 4,279 bytes long, while the buffer size is limited to 4,096 bytes.

This commit raises the line buffer size to 8,192 bytes, and also doubles
the conversion buffer to ensure enough space is still present to do the
proper conversions.

Resolves #28.