### PR TITLE
README: Add LIBINTL=FLAVOR to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ additionally, it can be entirely disabled.
 
 ```
 make LIBINTL=FLAVOR
-make DESTDIR=pkgdir prefix=/ install
+make LIBINTL=FLAVOR DESTDIR=pkgdir prefix=/ install
 ```
 
 where FLAVOR can be one of NONE, MUSL, NOOP (as detailed above).


### PR DESCRIPTION
Without this, libintl will always be compiled for the default NOOP
flavour, which does not help when you want =MUSL or =NONE.

This tripped us up at Adélie:
https://code.foxkit.us/adelie/packages/commit/5d228c9a