### PR TITLE
Makefile: fix install failure if path contains "m4/" string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,6 @@ $(DESTDIR)$(datadir)/%: %
 	$(INSTALL) -D -m 644 $< $@
 
 $(DESTDIR)$(acdir)/%: %
-	$(INSTALL) -D -l ../$(subst $(datarootdir)/,,$(datadir))/$< $(subst m4/,,$@)
+	$(INSTALL) -D -l ../$(subst $(datarootdir)/,,$(datadir))/$< $(patsubst %m4/,%,$(dir $@))/$(notdir $@)
 
 .PHONY: all clean install


### PR DESCRIPTION
Actually Makefile install recipe substitutes every occurence of "m4/" in
file name of the target of the rule($@), in an absolute path there could
more than one "m4/" occurence, so install will fail. Let's change
$(susbst ...) call with a call to sed substituting only last occurence
of "m4/".

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>