### PR TITLE
msgfmt: Allow space between --keyword and its arg

### DIFF
--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -333,6 +333,8 @@ int main(int argc, char**argv) {
 						mode = m_desktop;
 					} else if(streq(A+2, "xml")) {
 						mode = m_xml;
+					} else if(streq(A+2, "keyword")) {
+						arg++;
 					} else if((locale = strstarts(A+2, "locale="))) {
 					} else if(streq(A+2, "check")) {
 						strict = true;


### PR DESCRIPTION
While building mate-panel 1.24.0:

```
make[3]: Entering directory '/usr/src/packages/user/mate-panel/src/mate-panel-1.24.0/libmate-panel-applet'
/usr/bin/msgfmt --desktop --keyword Name --keyword Description --template org.mate.panel.TestApplet.mate-panel-applet.desktop.in -d ../po -o org.mate.panel.TestApplet.mate-panel-applet
fopen: No such file or directory
```

Fixes: 55a2119d06 ("msgfmt: support keyword, template, output options")