### PR TITLE
msgfmt: exit(1) if incorrectly used

### DIFF
--- a/src/msgfmt.c
+++ b/src/msgfmt.c
@@ -278,7 +278,7 @@ void set_file(int out, char* fn, FILE** dest) {
 int main(int argc, char**argv) {
 	if (argc == 1) {
 		syntax();
-		return 0;
+		return 1;
 	}
 
 	int arg = 1;
@@ -376,7 +376,7 @@ int main(int argc, char**argv) {
 				streq(A+1, "D")
 			) {
 				syntax();
-				return 0;
+				return 1;
 			} else if (streq(A+1, "l")) {
 				arg++;
 				locale = A;


### PR DESCRIPTION
This prevents builds from continuing seemingly fine when they are
actually not using this version of msgfmt correctly.