### PR TITLE
Use bmake compatible syntax where possible for all targets but install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,11 @@ datarootdir=$(prefix)/share
 datadir=$(datarootdir)/gettext-tiny
 acdir=$(datarootdir)/aclocal
 
-ifeq ($(LIBINTL), MUSL)
-	LIBSRC = libintl/libintl-musl.c
-	HEADERS =
-else ifeq ($(LIBINTL), NONE)
-	LIBSRC =
-	HEADERS =
-else
-	LIBSRC = libintl/libintl.c
-	HEADERS = libintl.h
-endif
-PROGSRC = $(sort $(wildcard src/*.c))
+-include libintl-$(LIBINTL).mak
+LIBSRC ?= libintl/libintl.c
+HEADERS ?= libintl.h
+
+PROGSRC != ls src/*.c
 
 PARSEROBJS = src/poparser.o src/StringEscape.o
 PROGOBJS = $(PROGSRC:.c=.o)
@@ -25,12 +19,10 @@ LIBOBJS = $(LIBSRC:.c=.o)
 OBJS = $(PROGOBJS) $(LIBOBJS)
 
 ALL_INCLUDES = $(HEADERS)
-ifneq ($(LIBINTL), NONE)
-ALL_LIBS=libintl.a
-endif
+ALL_LIBS ?= libintl.a
 ALL_TOOLS=msgfmt msgmerge xgettext autopoint
-ALL_M4S=$(sort $(wildcard m4/*.m4))
-ALL_DATA=$(sort $(wildcard data/*))
+ALL_M4S!=	ls m4/*.m4
+ALL_DATA!=	ls data/*
 
 CFLAGS  ?= -O0 -fPIC
 
@@ -42,7 +34,7 @@ INSTALL ?= ./install.sh
 
 -include config.mak
 
-LDLIBS:=$(shell echo "int main(){}" | $(CC) -liconv -x c - >/dev/null 2>&1 && printf %s -liconv)
+LDLIBS!=	echo "int main(){}" | $(CC) -liconv -x c - >/dev/null 2>&1 && printf %s -liconv
 
 BUILDCFLAGS=$(CFLAGS)
 
@@ -73,7 +65,7 @@ xgettext:
 	cp src/xgettext.sh ./xgettext
 
 autopoint: src/autopoint.in
-	cat $< | sed 's,@datadir@,$(datadir),' > $@
+	cat $> | sed 's,@datadir@,$(datadir),' > $@
 
 $(DESTDIR)$(libdir)/%.a: %.a
 	$(INSTALL) -D -m 755 $< $@

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make LIBINTL=FLAVOR
 make LIBINTL=FLAVOR DESTDIR=pkgdir prefix=/ install
 ```
 
-where FLAVOR can be one of NONE, MUSL, NOOP (as detailed above).
+where FLAVOR can be one of "none", "musl", NOOP (as detailed above).
 you can override any variables used in the Makefile (such as `CFLAGS`) by
 appending them to the `make` invocation, or by saving them into a file called
 `config.mak` before running `make`.

--- a/libintl-musl.mak
+++ b/libintl-musl.mak
@@ -1,0 +1,2 @@
+LIBSRC = libintl/libintl-musl.c
+HEADERS =

--- a/libintl-none.mak
+++ b/libintl-none.mak
@@ -1,0 +1,3 @@
+LIBSRC =
+HEADERS =
+ALL_LIBS =


### PR DESCRIPTION
Note that the install part is not working as expected yet with bmake, but at least it is now possible to build everything with bmake