### PR TITLE
xgettext: fix --version output

### DIFF
--- a/src/xgettext.sh
+++ b/src/xgettext.sh
@@ -16,7 +16,7 @@ syntax() {
 }
 
 show_version() {
-	printf "%s\n", "xgettext (GNU gettext-tools compatible) 99.9999.9999\n"
+	printf "%s\n" "xgettext (GNU gettext-tools-compatible) 99.99"
 	exit 0
 }
 


### PR DESCRIPTION
"\n" in the printf parameter doesn't expand and the comma gets printed after format string

i wasn't sure if it was okay to remove ` compatible`, so i replaced space with a dash, because [some things](https://gitlab.gnome.org/GNOME/gimp/-/blob/master/configure.ac#L676) parse the version as such:
```
xgettext --version | head -1 | cut -d" " -f4
```