### PR TITLE
Use CFLAGS and LDFLAGS when setting LDLIBS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ INSTALL ?= ./install.sh
 
 -include config.mak
 
-LDLIBS:=$(shell echo "int main(){}" | $(CC) -liconv -x c - >/dev/null 2>&1 && printf %s -liconv)
+LDLIBS:=$(shell echo "int main(){}" | $(CC) $(CFLAGS) $(LDFLAGS) -liconv -x c - >/dev/null 2>&1 && printf %s -liconv)
 
 BUILDCFLAGS=$(CFLAGS)
 


### PR DESCRIPTION
On systems where libiconv is in an unusual location, detecting it requires compiling the check program with CFLAGS and LDFLAGS.