### PR TITLE
autopoint: Fix unescaped parenthesis in ${…}

### DIFF
--- a/src/autopoint.in
+++ b/src/autopoint.in
@@ -15,13 +15,13 @@ dirprefix=""
 while read line
 do
   if [ "${line##*AC_CONFIG_AUX_DIR}" != "$line" ]; then
-    dirprefix="${line##*([}"
-    dirprefix="${dirprefix%%])*}"
+    dirprefix="${line##*'(['}"
+    dirprefix="${dirprefix%%'])'*}"
     mkdir -p "${dirprefix}"
   fi
   
   if [ "${line##*po/Makefile.in}" != "$line" ]; then
-    poprefix="${line##*[}"
+    poprefix="${line##*'['}"
     poprefix="${poprefix%%po/Makefile.in*}"
     install -D -m 644 @datadir@/data/autopoint_Makefile.in "./${poprefix}/po/Makefile.in.in"
   fi


### PR DESCRIPTION
Tested against mksh 59c, dash 0.5.12 and bash 5.1_p16 on Gentoo Linux while
in zbar-0.23.92 working directory.

A quick `git grep '${.*('` doesn't leads to other scripts with similar issues.

Closes: https://github.com/sabotage-linux/gettext-tiny/issues/65
