### PR TITLE
returns codeset in bind_textdomain_codeset

### DIFF
--- a/libintl/libintl.c
+++ b/libintl/libintl.c
@@ -73,8 +73,9 @@ char *bind_textdomain_codeset(const char *domainname, const char *codeset)
 {
 	if (!domainname || !*domainname || (codeset && strcasecmp(codeset, "UTF-8"))) {
 		errno = EINVAL;
+		return NULL;
 	}
-	return NULL;
+	return codeset;
 }
 
 /* trick configure tests checking for gnu libintl, as in the copy included in gdb */


### PR DESCRIPTION
Ref: https://www.man7.org/linux/man-pages/man3/bind_textdomain_codeset.3.html

> If successful, the bind_textdomain_codeset function returns the current codeset for domain domainname, after possibly changing it.

Returning NULL would make `gettext-rs` panic.