### PR TITLE
Improve POSIX Make compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ xgettext
 gettext
 ngettext
 envsubst
+ldlibs

--- a/Makefile
+++ b/Makefile
@@ -15,22 +15,19 @@ else ifeq ($(LIBINTL), NONE)
 	HEADERS =
 else
 	LIBSRC = libintl/libintl.c
-	HEADERS = libintl.h
+	HEADERS = include/libintl.h
 endif
-PROGSRC = $(sort $(wildcard src/*.c))
 
 PARSEROBJS = src/poparser.o src/StringEscape.o
-PROGOBJS = $(PROGSRC:.c=.o)
+PROGOBJS = src/msgmerge.o src/msgfmt.o
 LIBOBJS = $(LIBSRC:.c=.o)
-OBJS = $(PROGOBJS) $(LIBOBJS)
+OBJS = $(PARSEROBJS) $(PROGOBJS) $(LIBOBJS)
 
 ALL_INCLUDES = $(HEADERS)
 ifneq ($(LIBINTL), NONE)
 ALL_LIBS=libintl.a
 endif
 ALL_TOOLS=msgfmt msgmerge xgettext autopoint
-ALL_M4S=$(sort $(wildcard m4/*.m4))
-ALL_DATA=$(sort $(wildcard data/*))
 
 CFLAGS  ?= -O0 -fPIC
 
@@ -42,20 +39,17 @@ INSTALL ?= ./install.sh
 
 -include config.mak
 
-LDLIBS:=$(shell echo "int main(){}" | $(CC) $(CFLAGS) $(LDFLAGS) -liconv -x c - >/dev/null 2>&1 && printf %s -liconv)
-
 BUILDCFLAGS=$(CFLAGS)
 
 all: $(ALL_LIBS) $(ALL_TOOLS)
-
-install: $(ALL_LIBS:lib%=$(DESTDIR)$(libdir)/lib%) $(ALL_INCLUDES:%=$(DESTDIR)$(includedir)/%) $(ALL_TOOLS:%=$(DESTDIR)$(bindir)/%) $(ALL_M4S:%=$(DESTDIR)$(datadir)/%) $(ALL_M4S:%=$(DESTDIR)$(acdir)/%) $(ALL_DATA:%=$(DESTDIR)$(datadir)/%)
 
 clean:
 	rm -f $(ALL_LIBS)
 	rm -f $(OBJS)
 	rm -f $(ALL_TOOLS)
+	rm -f ldlibs
 
-%.o: %.c
+.c.o:
 	$(CC) $(BUILDCFLAGS) -c -o $@ $<
 
 libintl.a: $(LIBOBJS)
@@ -63,11 +57,14 @@ libintl.a: $(LIBOBJS)
 	$(AR) rc $@ $(LIBOBJS)
 	$(RANLIB) $@
 
-msgmerge: $(OBJS)
-	$(CC) -o $@ src/msgmerge.o $(PARSEROBJS) $(LDFLAGS) $(LDLIBS)
+ldlibs:
+	echo "int main(){}" | $(CC) $(CFLAGS) $(LDFLAGS) -liconv -x c - >/dev/null 2>&1 && printf %s -liconv || true > ldlibs
 
-msgfmt: $(OBJS)
-	$(CC) -o $@ src/msgfmt.o $(PARSEROBJS) $(LDFLAGS) $(LDLIBS)
+msgmerge: src/msgmerge.o $(PARSEROBJS) ldlibs
+	$(CC) -o $@ src/msgmerge.o $(PARSEROBJS) $(LDFLAGS) `cat ldlibs`
+
+msgfmt: src/msgfmt.o $(PARSEROBJS) ldlibs
+	$(CC) -o $@ src/msgfmt.o $(PARSEROBJS) $(LDFLAGS) `cat ldlibs`
 
 xgettext:
 	cp src/xgettext.sh ./xgettext
@@ -75,19 +72,12 @@ xgettext:
 autopoint: src/autopoint.in
 	cat $< | sed 's,@datadir@,$(datadir),' > $@
 
-$(DESTDIR)$(libdir)/%.a: %.a
-	$(INSTALL) -D -m 755 $< $@
-
-$(DESTDIR)$(includedir)/%.h: include/%.h
-	$(INSTALL) -D -m 644 $< $@
-
-$(DESTDIR)$(bindir)/%: %
-	$(INSTALL) -D -m 755 $< $@
-
-$(DESTDIR)$(datadir)/%: %
-	$(INSTALL) -D -m 644 $< $@
-
-$(DESTDIR)$(acdir)/%: %
-	$(INSTALL) -D -l ../$(subst $(datarootdir)/,,$(datadir))/$< $(patsubst %m4/,%,$(dir $@))/$(notdir $@)
+install: $(ALL_LIBS) $(ALL_INCLUDES) $(ALL_TOOLS)
+	$(INSTALL) -D -m 755 $(ALL_LIBS) $(DESTDIR)$(libdir)/
+	$(INSTALL) -D -m 644 $(ALL_INCLUDES) $(DESTDIR)$(includedir)/
+	$(INSTALL) -D -m 755 $(ALL_TOOLS) $(DESTDIR)$(bindir)/
+	$(INSTALL) -D -m 644 m4/*.m4 $(DESTDIR)$(datadir)/m4/
+	$(INSTALL) -D -m 644 data/* $(DESTDIR)$(datadir)/data/
+	for i in m4/*.m4 ; do $(INSTALL) -D -l $(datadir)/$$i $(DESTDIR)$(acdir)/$${i#m4/}; done
 
 .PHONY: all clean install

--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,44 @@
 # file atomically in the new location, rather than overwriting
 # existing files.
 #
+# Enhanced by Haelwenn (lanodan) Monnier to support multiple src arguments
+
+progname="$0"
 
 usage() {
-printf "usage: %s [-D] [-l] [-m mode] src dest\n" "$0" 1>&2
+printf "usage: %s [-D] [-l] [-m mode] src... dest\n" "$progname" 1>&2
 exit 1
+}
+
+install() {
+	src="$1"
+	dst="$2"
+	tmp="$3"
+
+	umask 077
+
+	test -d "$dst" && {
+		printf "%s: Destination file '%s' is a directory\n" "$progname" "$dst" 1>&2
+		exit 1
+	}
+	test -d "$src" && {
+		printf "%s: Source file '%s' is a directory\n" "$progname" "$src" 1>&2
+		exit 1
+	}
+
+	set -C
+	set -e
+
+	trap 'rm -f "$tmp"' EXIT INT QUIT TERM HUP
+
+	if test "$symlink" ; then
+		ln -s "$src" "$tmp"
+	else
+		cat < "$src" > "$tmp"
+		chmod "$mode" "$tmp"
+	fi
+
+	mv -f "$tmp" "$dst"
 }
 
 mkdirp=
@@ -27,41 +61,39 @@ esac
 done
 shift $(($OPTIND - 1))
 
-test "$#" -eq 2 || usage
-src=$1
-dst=$2
-tmp="$dst.tmp.$$"
+test 1 -lt "$#" || usage
 
-case "$dst" in
-*/) printf "%s: %s ends in /\n", "$0" "$dst" 1>&2 ; exit 1 ;;
-esac
+for dst in "$@" ; do :; done
+
+dir=
+test 2 -lt "$#" && dir="${dst}/"
 
 set -C
 set -e
 
-if test "$mkdirp" ; then
-umask 022
-case "$2" in
-*/*) mkdir -p "${dst%/*}" ;;
-esac
-fi
+while test 1 -lt "$#"; do
+	src="$1"
+	dst="$2"
+	shift
 
-trap 'rm -f "$tmp"' EXIT INT QUIT TERM HUP
+	if test -n "$dir"; then
+		dst="${dir}${src#*/}"
+	else
+		case "$dst" in
+		*/) dst="${dst}${src#*/}" ;;
+		esac
+	fi
 
-umask 077
+	if test "$mkdirp" ; then
+	umask 022
+	case "$dst" in
+	*/*) mkdir -p "${dst%/*}" ;;
+	esac
+	fi
 
-if test "$symlink" ; then
-ln -s "$1" "$tmp"
-else
-cat < "$1" > "$tmp"
-chmod "$mode" "$tmp"
-fi
+	tmp="$dst.tmp.$$.$#"
 
-mv -f "$tmp" "$2"
-test -d "$2" && {
-rm -f "$2/$tmp"
-printf "%s: %s is a directory\n" "$0" "$dst" 1>&2
-exit 1
-}
+	install "${src:?}" "${dst:?}" "${tmp:?}"
+done
 
 exit 0


### PR DESCRIPTION
What remains non-POSIX is `ifeq` which pdpmake has but NetBSD make doesn't.
